### PR TITLE
Optionally throw errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ isSchemaValid = validateSchema({
 // false, because properties is not in correct format
 ```
 
+By default, jsen simply returns `false` if a schema is invalid. If you would like more detail about which part of your schema failed, you can ask jsen to throw errors at you.
+
+```javascript
+var validateSchema = jsen({"$ref": "http://json-schema.org/draft-04/schema#"}, true);
+var isSchemaValid = validateSchema({ type: 'object' }); // true
+
+try {
+    validateSchema({
+        type: 'object',
+        properties: ['string', 'number']
+    });
+} catch (e) {
+    e.message === 'Invalid input for: {"type":"object","additionalProperties":{"$ref":"#"},"default":{}}' //true
+}
+```
+
 ## JSON Schema
 
 `jsen` fully implements draft 4 of the [JSON Schema specification](http://json-schema.org/documentation.html). Check out this [excellent guide to JSON Schema](http://spacetelescope.github.io/understanding-json-schema/UnderstandingJSONSchema.pdf) by Michael Droettboom, et al.

--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -429,7 +429,7 @@ formats.ipv6 = /^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1
 // reference: http://stackoverflow.com/questions/106179/regular-expression-to-match-dns-hostname-or-ip-address#answer-3824105
 formats.hostname = /^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$/;
 
-function createValidator(schema) {
+function createValidator(schema, throwErrors) {
     if (!type.isObject(schema)) {
         throw new Error(strings.invalidSchema);
     }
@@ -525,6 +525,11 @@ function createValidator(schema) {
             }
         }
 
+        if (throwErrors) {
+          var escaped = JSON.stringify(schema).replace(/"/g, '\\"')
+          source('if (!ok) throw(new Error("Invalid input for: ' + escaped + '"))');
+        }
+
         source('return ok');
 
         return source.compile(context);
@@ -533,12 +538,11 @@ function createValidator(schema) {
     return resolve(schema, compile);
 }
 
-module.exports = function jsen(schema) {
-    return createValidator(schema);
+module.exports = function jsen(schema, throwErrors) {
+    return createValidator(schema, throwErrors);
 };
 
 /*
-    TODO: Error reporting
-          Extensibility (custom formats + types)
+    TODO: Extensibility (custom formats + types)
           Replace validation in request-validator
 */

--- a/test/errors.js
+++ b/test/errors.js
@@ -1,0 +1,18 @@
+/* global describe, it */
+'use strict';
+
+var assert = require('assert'),
+    jsen = require('../index.js');
+
+describe('errors', function () {
+    it('should throw an error on invalid input if asked', function () {
+        var schema = { type: 'number' },
+            validate = jsen(schema, true);
+
+        var errorMatcher = /Invalid input/;
+        assert.throws(function(){validate()}, errorMatcher);
+        assert.throws(function(){validate('invalid'), errorMatcher});
+
+        assert(validate(123));
+    });
+});


### PR DESCRIPTION
These errors aren't quite as helpful as I'd like. Ideally they'd provide both the schema the item was compared against and the input that was provided. This is better than nothing, though.