### PR TITLE
added support for IE8

### DIFF
--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -37,7 +37,7 @@ function isInteger(obj) {
     return (obj | 0) === obj;   // jshint ignore: line
 }
 
-types.null = function (path) {
+types['null'] = function (path) {
     return path + ' === null';
 };
 
@@ -88,8 +88,8 @@ keywords.type = function (context) {
     }
 };
 
-keywords.enum = function (context) {
-    var arr = context.schema.enum,
+keywords['enum'] = function (context) {
+    var arr = context.schema['enum'],
         clauses = [],
         value, enumType, i;
 

--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -647,7 +647,7 @@ function build(schema, def, additional, resolver) {
     schema = resolver.resolve(schema);
 
     if (def === undefined && schema.hasOwnProperty('default')) {
-        def = clone(schema.default);
+        def = clone(schema['default']);
     }
 
     defType = type(def);


### PR DESCRIPTION
Hi Veli.

First of all thanks for a great json schema library. I really like it.
I started to use library is-my-json-valid but your library has better options and everything what I want from json validator library.

I added support for IE8. You are not able to use keywords enum, default and null without [''] in IE8.
Thanks for merge
