### PR TITLE
Problem with $ref

### DIFF
--- a/test/draft4/ref.json
+++ b/test/draft4/ref.json
@@ -140,5 +140,40 @@
                 "valid": false
             }
         ]
+    },
+    {
+        "description": "ref with array and required",
+        "schema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "foo": {"$ref": "#"}
+                },
+                "required": ["foo"]
+            }
+        },
+        "tests": [
+            {
+                "description": "match",
+                "data": [{"foo": []}],
+                "valid": true
+            },
+            {
+                "description": "recursive match",
+                "data": [{"foo": [{"foo": []}]}],
+                "valid": true
+            },
+            {
+                "description": "mismatch",
+                "data": [{"bar": []}],
+                "valid": false
+            },
+            {
+                "description": "recursive mismatch",
+                "data": [{"foo": [{"foo": []}, {"bar": []}]}],
+                "valid": false
+            }
+        ]
     }
 ]


### PR DESCRIPTION
The schema in the attached test cases combines `$ref` with array and `required`. That seems to confuse jsen:

```json
{
    "type": "array",
    "items": {
        "type": "object",
        "properties": {
            "foo": {"$ref": "#"}
        },
        "required": ["foo"]
    }
}
```