### PR TITLE
Missing $ref

### DIFF
--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -828,8 +828,6 @@ function jsen(schema, options) {
                 pathExp = getPathExpression(path);
                 index = declare(0);
 
-                console.log(schema);
-
                 code('if (!' + cachedRef + '(' + path + ')) {')
                     ('if (' + cachedRef + '.errors) {')
                         ('errors.push.apply(errors, ' + cachedRef + '.errors)')

--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -644,14 +644,14 @@ function clone(obj) {
     return cloned;
 }
 
-function build(schema, def, additional, resolver) {
+function build(schema, def, additional, resolver, missing$Ref) {
     var defType, defValue, key, i;
 
     if (type(schema) !== 'object') {
         return def;
     }
 
-    schema = resolver.resolve(schema);
+    schema = resolver.resolve(schema, missing$Ref);
 
     if (def === undefined && schema.hasOwnProperty('default')) {
         def = clone(schema['default']);
@@ -704,6 +704,7 @@ function jsen(schema, options) {
     options = options || {};
 
     var resolver = new SchemaResolver(schema, options.schemas),
+        missing$Ref = options.missing$Ref || false,
         counter = 0,
         id = function () { return 'i' + (counter++); },
         funcache = {},
@@ -718,7 +719,7 @@ function jsen(schema, options) {
         };
 
     function cache(schema) {
-        var deref = resolver.resolve(schema),
+        var deref = resolver.resolve(schema, missing$Ref),
             ref = schema.$ref,
             cached = funcache[ref],
             func;
@@ -827,6 +828,8 @@ function jsen(schema, options) {
                 pathExp = getPathExpression(path);
                 index = declare(0);
 
+                console.log(schema);
+
                 code('if (!' + cachedRef + '(' + path + ')) {')
                     ('if (' + cachedRef + '.errors) {')
                         ('errors.push.apply(errors, ' + cachedRef + '.errors)')
@@ -907,13 +910,15 @@ function jsen(schema, options) {
         compiled = code.compile(scope);
 
         compiled.errors = [];
+        compiled.missing = resolver.missing;
 
         compiled.build = function (initial, options) {
             return build(
                 schema,
                 (options && options.copy === false ? initial : clone(initial)),
                 options && options.additionalProperties,
-                resolver);
+                resolver,
+                missing$Ref);
         };
 
         return compiled;

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -116,18 +116,20 @@ function SchemaResolver(rootSchema, external) {  // jshint ignore: line
         null;
 
     if (this.resolvers) {
-        var len = this.resolvers.length,
-            missingMap = this.missing.reduce(function (map, key) {
-                map[key] = true;
-                return map;
-            }, {}),
+        var resLen = this.resolvers.length,
+            mapLen = this.missing.length,
+            missingMap = {},
             subMissing,
             subMissingLen,
             subMissingName,
             i,
             j;
 
-        for (i = 0; i < len; i++) {
+        for (i = 0; i < mapLen; i++) {
+            missingMap[this.missing[i]] = true;
+        }
+
+        for (i = 0; i < resLen; i++) {
             subMissing = this.resolvers[i].missing;
             subMissingLen = subMissing.length;
 
@@ -136,7 +138,7 @@ function SchemaResolver(rootSchema, external) {  // jshint ignore: line
 
                 if (!missingMap.hasOwnProperty(subMissingName)) {
                     missingMap[subMissingName] = true;
-                    this.missing[len++] = subMissing[j];
+                    this.missing[resLen++] = subMissing[j];
                 }
             }
         }

--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -40,8 +40,7 @@ function get(obj, key) {
                 remaining.shift();
                 parts.shift();
             }
-        }
-        else {
+        } else {
             // treat like normal simple keys
             obj = obj[parts.shift()];
         }
@@ -95,7 +94,8 @@ function refFromId(obj, ref) {
 function getResolvers(schemas) {
     var keys = Object.keys(schemas),
         resolvers = {},
-        key, i;
+        key,
+        i;
 
     for (i = 0; i < keys.length; i++) {
         key = keys[i];
@@ -109,13 +109,41 @@ function SchemaResolver(rootSchema, external) {  // jshint ignore: line
     this.rootSchema = rootSchema;
     this.cache = {};
     this.resolved = null;
+    this.missing = [];
 
     this.resolvers = external && typeof external === 'object' ?
         getResolvers(external) :
         null;
+
+    if (this.resolvers) {
+        var len = this.resolvers.length,
+            missingMap = this.missing.reduce(function (map, key) {
+                map[key] = true;
+                return map;
+            }, {}),
+            subMissing,
+            subMissingLen,
+            subMissingName,
+            i,
+            j;
+
+        for (i = 0; i < len; i++) {
+            subMissing = this.resolvers[i].missing;
+            subMissingLen = subMissing.length;
+
+            for (j = 0; j < subMissingLen; j++) {
+                subMissingName = subMissing[j];
+
+                if (!missingMap.hasOwnProperty(subMissingName)) {
+                    missingMap[subMissingName] = true;
+                    this.missing[len++] = subMissing[j];
+                }
+            }
+        }
+    }
 }
 
-SchemaResolver.prototype.resolveRef = function (ref) {
+SchemaResolver.prototype.resolveRef = function (ref, missing$Ref) {
     var err = new Error(INVALID_SCHEMA_REFERENCE + ' ' + ref),
         root = this.rootSchema,
         externalResolver,
@@ -149,7 +177,14 @@ SchemaResolver.prototype.resolveRef = function (ref) {
     }
 
     if (!dest || typeof dest !== 'object') {
-        throw err;
+        if (missing$Ref) {
+            this.missing.push(ref);
+            dest = {
+                additionalProperties: true
+            };
+        } else {
+            throw err;
+        }
     }
 
     if (this.cache[ref] === dest) {
@@ -165,7 +200,7 @@ SchemaResolver.prototype.resolveRef = function (ref) {
     return dest;
 };
 
-SchemaResolver.prototype.resolve = function (schema) {
+SchemaResolver.prototype.resolve = function (schema, missing$Ref) {
     if (!schema || typeof schema !== 'object') {
         return schema;
     }
@@ -181,7 +216,7 @@ SchemaResolver.prototype.resolve = function (schema) {
         return resolved;
     }
 
-    resolved = this.resolveRef(ref);
+    resolved = this.resolveRef(ref, missing$Ref);
 
     if (schema === this.rootSchema && schema !== resolved) {
         // substitute the resolved root schema

--- a/test/ignore-missing.js
+++ b/test/ignore-missing.js
@@ -1,0 +1,67 @@
+/* global describe, it */
+'use strict';
+
+var assert = assert || require('assert'),
+    jsen = jsen || require('../index.js');
+
+describe('missing $ref', function () {
+    it('passes validation with ignore missing $ref', function () {
+        var schema = {
+                type: 'object',
+                properties: {
+                    test1: { $ref: '#external1'},   //missing
+                    test2: {
+                        type: 'object',
+                        properties: {
+                            test21: {$ref: '#external2'}    //missing
+                        }
+                    },
+                    test3: { $ref: '#external3'}    //exist
+                },
+                additionalProperties: false
+            },
+            external3 = {
+                type: 'object',
+                properties: {
+                    test31: { $ref: '#external31'}, //missing
+                    test32: {
+                        type: 'number'
+                    },
+                    test33: { $ref: '#external31'}  //duplicate
+                }
+            },
+            validate = jsen(schema, {
+                schemas: {
+                    external3: external3
+                },
+                missing$Ref: true
+            }),
+            missingTest = {
+                test1: 1,
+                test2: {
+                    test21: 21
+                },
+                test3: {
+                    test31: 31,
+                    test32: 32
+                }
+            },
+            invalidTest = {
+                test1: '1',
+                test2: {
+                    test21: 21
+                },
+                test3: {
+                    test31: 31,
+                    test32: '32',
+                    test33: 33
+                }
+            },
+            ret1 = validate(missingTest),
+            ret2 = validate(invalidTest);
+
+        assert(ret1);    // true
+        assert(!ret2);   // !false
+        assert.deepEqual(validate.missing, ['#external1', '#external2', '#external31']);
+    });
+});


### PR DESCRIPTION
Hey, my proposal is to add missing$Ref option which ignore not delivered $ref and add to validate object (next to "errors" property) "missing" property containing these $refs list.

Inspired by https://github.com/geraintluff/tv4#usage-1-simple-validation

Sorry, can not build /dist (command not work on my system)