### PR TITLE
Speed up

### DIFF
--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -384,7 +384,7 @@ keywords.patternProperties = keywords.additionalProperties = function (context) 
     for (i = 0; i < propKeys.length; i++) {
         propKey = propKeys[i];
 
-        context.code('if (' + key + ' === "' + propKey + '") {');
+        context.code((i ? 'else ' : '' ) + 'if (' + key + ' === "' + propKey + '") {');
 
         if (addPropsCheck) {
             context.code(found + ' = true');


### PR DESCRIPTION
Using 'else if' instead of 'if' for next tests we can speed up this fragment of code ( 'else if' is 33% faster than 'multiple if' in test with 10 properties). I also tested 'switch' and 'hash table' and results are similar on node.js