### PR TITLE
Fix regexp for JSON Pointer

### DIFF
--- a/lib/resolver.js
+++ b/lib/resolver.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var metaschema = require('./metaschema.json'),
-    refRegex = /#?(\/?\w+)*$/,
+    refRegex = /^#?(\/(~0|~1|[^\/~])+)*$/,
     INVALID_SCHEMA_REFERENCE = 'jsen: invalid schema reference';
 
 function get(obj, key) {


### PR DESCRIPTION
Current regexp doesn't support support symbols in JSON Pointer other than `\w`. Also it has a really bad performance with long strings (e.g. `'#/definitions/extractors/DynamicButtonLastVenuesExtractor$'`)