### PR TITLE
 workaround for NetSuite. 

### DIFF
--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -37,8 +37,13 @@ function appendToPath(path, key) {
 }
 
 function type(obj) {
-    var str = Object.prototype.toString.call(obj);
-    return str.substr(8, str.length - 9).toLowerCase();
+    if (obj === undefined) {
+        return 'undefined';
+    }
+    else {
+        var str = Object.prototype.toString.call(obj);
+        return str.substr(8, str.length - 9).toLowerCase();
+    }
 }
 
 function isInteger(obj) {


### PR DESCRIPTION
 this function throws a TypeError if the argument is **undefined** in the NetSuite (Rhino) environment.