### PR TITLE
Fix schema bug with type "integer" and keywords "maximum" and/or "minimum"

### DIFF
--- a/lib/jsen.js
+++ b/lib/jsen.js
@@ -969,10 +969,19 @@ ValidationContext.prototype.generate = function () {
         keywords[keyword](context);    // jshint ignore: line
     }
 
+    var hasType = (schemaKeys.type && schemaKeys.type.length);
+    if (hasType) {
+        this.code('if (!(' + schemaKeys.type.map(function (type) {
+            return types[type] ? types[type](path) : 'true';
+        }).join(' || ') + ')) {');
+        this.error('type');
+        this.code('}');
+    }
+
     for (i = 0; i < typeKeys.length; i++) {
         validatedType = typeKeys[i];
 
-        this.code((i ? 'else ' : '') + 'if (' + types[validatedType](path) + ') {');
+        this.code((hasType ? 'else ' : '') + 'if (' + types[validatedType](path) + ') {');
 
         schemaKeys.perType[validatedType].forEach(generateForKeyword);
 
@@ -987,19 +996,10 @@ ValidationContext.prototype.generate = function () {
         }
     }
 
-    if (schemaKeys.type) {              // we have types in the schema
-        if (schemaKeys.type.length) {   // case 1: we still have some left to check
-            this.code((typeKeys.length ? 'else ' : '') + 'if (!(' + schemaKeys.type.map(function (type) {
-                return types[type] ? types[type](path) : 'true';
-            }).join(' || ') + ')) {');
-            this.error('type');
-            this.code('}');
-        }
-        else {
-            this.code('else {');             // case 2: we don't have any left to check
-            this.error('type');
-            this.code('}');
-        }
+    if (schemaKeys.type && !schemaKeys.type.length) {
+        this.code('else {');
+        this.error('type');
+        this.code('}');
     }
 
     schemaKeys.allType.forEach(function (keyword) {

--- a/test/integer.js
+++ b/test/integer.js
@@ -24,6 +24,58 @@ describe('type: integer', function () {
         assert(validate(123));
     });
 
+    it('boolean-able', function () {
+        var schema = { type: ['integer', 'boolean'] },
+            validate = jsen(schema);
+
+        assert(!validate(undefined));
+
+        assert(validate(true));
+        assert(validate(false));
+        assert(validate(123));
+        assert(!validate(123.123));
+    });
+
+    it('boolean-able with minimum', function () {
+        var schema = { type: ['integer', 'boolean'], minimum: 0 },
+            validate = jsen(schema);
+
+        assert(!validate(undefined));
+
+        assert(validate(true));
+        assert(validate(false));
+        assert(validate(123));
+        assert(!validate(123.123));
+        assert(!validate(-10));
+    });
+
+    it('boolean-able with maximum', function () {
+        var schema = { type: ['integer', 'boolean'], maximum: 124 },
+            validate = jsen(schema);
+
+        assert(!validate(undefined));
+
+        assert(validate(true));
+        assert(validate(false));
+        assert(validate(123));
+        assert(!validate(123.123));
+        assert(!validate(125));
+    });
+
+    it('boolean-able with maximum and minimum', function () {
+        var schema = { type: ['integer', 'boolean'], maximum: 124, minimum: 0 },
+            validate = jsen(schema);
+
+        assert(!validate(undefined));
+
+        assert(validate(true));
+        assert(validate(false));
+        assert(validate(123));
+        assert(!validate(123.123));
+        assert(!validate(125));
+        assert(!validate(-10));
+    });
+
     it('type', function () {
         var schema = { type: 'integer' },
             validate = jsen(schema);
@@ -98,6 +150,7 @@ describe('type: integer', function () {
         assert(validate(-12));
         assert(validate(75));
         assert(validate(76));
+        assert(!validate(75.123));
     });
 
     it('multipleOf', function () {
@@ -109,5 +162,6 @@ describe('type: integer', function () {
         assert(validate(14));
         assert(validate(-49));
         assert(validate(77));
+        assert(!validate(77.000000000001));
     });
 });

--- a/test/integer.js
+++ b/test/integer.js
@@ -54,6 +54,7 @@ describe('type: integer', function () {
 
         assert(validate(7));
         assert(validate(999));
+        assert(!validate(7.7));
     });
 
     it('exclusiveMinimum', function () {
@@ -80,6 +81,7 @@ describe('type: integer', function () {
         assert(validate(-12));
         assert(validate(76));
         assert(validate(77));
+        assert(!validate(76.77));
     });
 
     it('exclusiveMaximum', function () {


### PR DESCRIPTION
It looks like the issue is because there is an assumption of the type 'number' when the keywords 'maximum' or 'minimum' are being used, at around https://github.com/bugventure/jsen/blob/master/lib/jsen.js#L518-L519
